### PR TITLE
Prevent double counting bug

### DIFF
--- a/app/voting/signals.py
+++ b/app/voting/signals.py
@@ -46,7 +46,7 @@ def initialize_correlations(sender, created, instance, **kwargs):
 )
 def update_correlations(sender, instance, created, **kwargs):
     if not created:
-        # Do not update correlations for already existing correlations
+        # Do not update correlations for already existing votes
         return
 
     # Use Exponential Moving Average to track correlation weights

--- a/app/voting/signals.py
+++ b/app/voting/signals.py
@@ -44,7 +44,11 @@ def initialize_correlations(sender, created, instance, **kwargs):
     sender=UserVote,
     dispatch_uid='update_correlations'
 )
-def update_correlations(sender, instance, **kwargs):
+def update_correlations(sender, instance, created, **kwargs):
+    if not created:
+        # Do not update correlations for already existing correlations
+        return
+
     # Use Exponential Moving Average to track correlation weights
     # EMA will keep values stable, but allow them to drift in response to changes in patterns.
     # Higher the weight, the slower it will react to changes.


### PR DESCRIPTION
As a result of updating correlations on every save of a `UserVote`, there was the unfortunate consequence that saving the same `UserVote` object multiple times would result in the associated correlations being inflated incorrectly.

This disables updating correlations when changing an already existing `UserVote`. An alternate solution would be to only update correlations if the polarity changes, but for the moment it was considered unnecessarily complicated and the impact of a lost data point should be sufficiently low.