### PR TITLE
Add consensus endpoint

### DIFF
--- a/app/voting/serializers/__init__.py
+++ b/app/voting/serializers/__init__.py
@@ -4,3 +4,4 @@ from .room import RoomSerializer
 from .voting_session import VotingSessionSerializer
 from .user_vote import UserVoteSerializer
 from .suggestion import SuggestionSerializer
+from .consensus import ConsensusSerializer

--- a/app/voting/serializers/consensus.py
+++ b/app/voting/serializers/consensus.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class ConsensusSerializer(serializers.Serializer):
+    id = serializers.IntegerField()

--- a/app/voting/tests/it/test_consensus.py
+++ b/app/voting/tests/it/test_consensus.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+from voting.factories import BallotOptionFactory, VotingSessionFactory, UserVoteFactory
+
+
+class ConsensusTests(TestCase):
+    def test_consensus__create__prohibited(self):
+        url = reverse('consensus-list')
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_consensus__delete__prohibited(self):
+        option = BallotOptionFactory.create()
+        url = reverse('consensus-detail', kwargs={'pk': option.id})
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_consensus__update__prohibited(self):
+        option = BallotOptionFactory.create()
+        url = reverse('consensus-detail', kwargs={'pk': option.id})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_consensus__list_no_token__error(self):
+        url = reverse('consensus-list')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_consensus__list_with_token__success(self):
+        session = VotingSessionFactory.create()
+        url = reverse('consensus-list')
+        response = self.client.get(url + f'?token={session.id}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        json = response.json()
+        self.assertIn('results', json)
+        self.assertEqual(json['results'], [])
+
+    def test_consensus__voted_for__shows(self):
+        vote = UserVoteFactory.create(polarity=True)
+        url = reverse('consensus-list')
+        response = self.client.get(url + f'?token={vote.session.id}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        json = response.json()
+        self.assertIn('results', json)
+        self.assertEqual(json['results'], [{
+            'id': vote.option.id
+        }])
+
+    def test_consensus__voted_against__excluded(self):
+        vote = UserVoteFactory.create(polarity=False)
+        url = reverse('consensus-list')
+        response = self.client.get(url + f'?token={vote.session.id}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        json = response.json()
+        self.assertIn('results', json)
+        self.assertEqual(json['results'], [])
+
+    def test_consensus__vote_missing__excluded(self):
+        # Exclude options that were voted for by one session but are missing a vote by another
+        vote = UserVoteFactory.create(polarity=True)
+        VotingSessionFactory.create(room=vote.session.room)
+        url = reverse('consensus-list')
+        response = self.client.get(url + f'?token={vote.session.id}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        json = response.json()
+        self.assertIn('results', json)
+        self.assertEqual(json['results'], [])

--- a/app/voting/urls.py
+++ b/app/voting/urls.py
@@ -5,7 +5,8 @@ from .views import (
     RoomViewSet,
     VotingSessionViewSet,
     UserVoteViewSet,
-    SuggestionViewSet
+    SuggestionViewSet,
+    ConsensusViewSet
 )
 
 router = routers.DefaultRouter()
@@ -15,3 +16,4 @@ router.register(r'room', RoomViewSet)
 router.register(r'session', VotingSessionViewSet)
 router.register(r'vote', UserVoteViewSet)
 router.register(r'suggest', SuggestionViewSet, basename='suggest')
+router.register(r'picks', ConsensusViewSet, basename='consensus')

--- a/app/voting/views/__init__.py
+++ b/app/voting/views/__init__.py
@@ -4,3 +4,4 @@ from .room import RoomViewSet
 from .voting_session import VotingSessionViewSet
 from .user_vote import UserVoteViewSet
 from .suggestion import SuggestionViewSet
+from .consensus import ConsensusViewSet

--- a/app/voting/views/consensus.py
+++ b/app/voting/views/consensus.py
@@ -1,0 +1,23 @@
+from rest_framework import viewsets
+
+from voting.models import BallotOption
+from voting.serializers import ConsensusSerializer
+from .utils import get_voting_session_token
+
+
+class ConsensusViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = BallotOption.objects.all().order_by('created')
+    serializer_class = ConsensusSerializer
+
+    def get_queryset(self):
+        session_token = get_voting_session_token(self.request)
+
+        return self.queryset.filter(
+            # Only show options for the ballot that this session belongs to
+            ballot__room__votingsession=session_token
+        ).exclude(
+            # Do not include options that have received any votes against
+            ballot__room__votingsession__uservote__polarity=False
+        ).exclude(
+            ballot__room__votingsession__uservote=None
+        ).values('id')


### PR DESCRIPTION
Adds an endpoint to list all options that have been voted for by all sessions in the user's room. If any sessions have not voted on the option, or voted against, the option will not be listed.

This is currently failing due to [encountering Django bug #30739](https://code.djangoproject.com/ticket/30739), which was fixed in django/django#11734 for Django 3.0. I don't know if this fix will make it into Django 2.2 yet, and if it does not I will have to find a workaround or upgrade to Django 3.0.

Closes #6