### PR TITLE
Automatically push to AWS ECR on merge to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,9 @@ before_install:
 
 script:
   - ./scripts/test
+
+deploy:
+  provider: script
+  script: bash scripts/deploy
+  on:
+    branch: master

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,21 @@
+set -e
+
+if [ -z "$AWS_ECR_ENDPOINT" ]
+then
+    echo "AWS_ECR_ENDPOINT environment variable missing"
+    exit 1
+fi;
+
+$(aws ecr get-login --no-include-email --region us-east-1)
+
+cd app/
+docker build -t suggestion-api .
+
+# Tag with `latest` as well as the current date in the UTC timezone
+# Subsequent deploys on the same date will overwrite this version
+DATE=$(date -u +'%Y-%m-%d')
+docker tag suggestion-api:latest $AWS_ECR_ENDPOINT:$DATE
+docker push $AWS_ECR_ENDPOINT:$DATE
+docker tag suggestion-api:latest $AWS_ECR_ENDPOINT:latest
+docker push $AWS_ECR_ENDPOINT:latest
+

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,6 @@
 set -e
 
-test -f .env &&  set -a && . .env
+test -f .env && set -a && . .env
 
 python3 -m flake8 app/
 


### PR DESCRIPTION
As part of the ultimate goal of #8, we would like to track our container images in AWS ECR. This adds functionality for that, versioning both by date and `latest` each time a change is merged into `master`.

Multiple merges in a day will leave containers orphaned, though, so it may be desirable to use `TRAVIS_COMMIT` or `git rev-parse --short HEAD` to incorporate the git hash with the day version so each deploy is unique. This isn't 100% optimal, though, since it means that multiple deploys in a day aren't trivially sortable. A optimal choice would work locally as well as in Travis, and allow multiple deploys to be sorted in the correct order. Incorporating the time of deploy may accomplish that, but feels unnecessarily verbose.